### PR TITLE
Fix mobile taskbar and start menu layout

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -22,7 +22,9 @@
   --accent-soft: rgba(21, 101, 216, 0.12);
   --shadow: 0 18px 48px rgba(42, 54, 75, 0.18);
   --shadow-active: 0 24px 70px rgba(23, 34, 51, 0.28);
-  --taskbar-height: 54px;
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --taskbar-content-height: 54px;
+  --taskbar-height: calc(var(--taskbar-content-height) + var(--safe-area-bottom));
   --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
 }
 
@@ -51,12 +53,14 @@ html,
 body,
 #root {
   min-width: 320px;
+  height: 100%;
   min-height: 100%;
   margin: 0;
 }
 
 body {
   min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
 }
 
@@ -75,7 +79,10 @@ a {
 
 .desktop {
   position: relative;
+  height: 100vh;
+  height: 100dvh;
   min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
   background:
     radial-gradient(circle at 18% 18%, var(--wallpaper-a), transparent 32%),
@@ -408,7 +415,7 @@ a {
   gap: 10px;
   align-items: center;
   height: var(--taskbar-height);
-  padding: 8px 12px;
+  padding: 8px 12px calc(8px + var(--safe-area-bottom));
   border-top: 1px solid var(--border-strong);
   background: color-mix(in srgb, var(--surface) 86%, transparent);
   backdrop-filter: blur(18px);
@@ -474,10 +481,11 @@ a {
   left: 0;
   z-index: 2;
   display: grid;
-  grid-template-columns: 230px;
+  grid-template-columns: minmax(0, 230px);
   width: min(230px, calc(100vw - 24px));
   max-height: min(430px, calc(100vh - var(--taskbar-height) - 24px));
-  overflow: visible;
+  max-height: min(430px, calc(100dvh - var(--taskbar-height) - 24px));
+  overflow: hidden;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
   background: color-mix(in srgb, var(--surface) 94%, var(--surface-muted));
@@ -486,7 +494,7 @@ a {
   backdrop-filter: blur(18px);
 
   &[data-submenu-open="true"] {
-    grid-template-columns: 230px 270px;
+    grid-template-columns: minmax(0, 230px) minmax(0, 270px);
     width: min(500px, calc(100vw - 24px));
   }
 }
@@ -501,6 +509,8 @@ a {
 
 .start-menu__items {
   min-width: 0;
+  min-height: 0;
+  max-height: inherit;
   overflow-y: auto;
   padding: 8px;
 }
@@ -537,11 +547,18 @@ a {
   }
 
   &:focus-visible,
-  &:hover,
   &[data-active="true"] {
     border-color: var(--accent);
     background: var(--accent-soft);
     outline: none;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      outline: none;
+    }
   }
 
   &:active {
@@ -569,6 +586,7 @@ a {
   align-content: start;
   gap: 2px;
   min-width: 0;
+  min-height: 0;
   max-height: inherit;
   overflow-y: auto;
   padding: 8px;
@@ -608,11 +626,18 @@ a {
     white-space: nowrap;
   }
 
-  &:focus-visible,
-  &:hover {
+  &:focus-visible {
     border-color: var(--accent);
     background: var(--accent-soft);
     outline: none;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      outline: none;
+    }
   }
 
   &:active {
@@ -1109,7 +1134,7 @@ a {
 
 @media (max-width: 760px) {
   :root {
-    --taskbar-height: 66px;
+    --taskbar-content-height: 66px;
   }
 
   .desktop__icons {
@@ -1135,7 +1160,7 @@ a {
   .taskbar {
     grid-template-columns: auto minmax(0, 1fr) auto;
     gap: 6px;
-    padding: 8px;
+    padding: 8px 8px calc(8px + var(--safe-area-bottom));
   }
 
   .taskbar__start,
@@ -1144,23 +1169,32 @@ a {
   }
 
   .start-menu {
-    grid-template-columns: 1fr;
-    width: min(330px, calc(100vw - 16px));
-    overflow: hidden;
+    position: fixed;
+    right: 8px;
+    bottom: calc(var(--taskbar-height) + 8px);
+    left: 8px;
+    grid-template-columns: minmax(0, 1fr);
+    width: auto;
+    max-height: min(520px, calc(100vh - var(--taskbar-height) - 16px));
+    max-height: min(520px, calc(100dvh - var(--taskbar-height) - 16px));
 
     &[data-submenu-open="true"] {
-      grid-template-columns: 1fr;
-      width: min(330px, calc(100vw - 16px));
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-rows: minmax(0, 0.95fr) minmax(0, 1.05fr);
+      width: auto;
+      height: min(520px, calc(100vh - var(--taskbar-height) - 16px));
+      height: min(520px, calc(100dvh - var(--taskbar-height) - 16px));
     }
   }
 
-  .start-menu__items {
+  .start-menu[data-submenu-open="true"] .start-menu__items {
     border-right: 0;
     border-bottom: 1px solid var(--border);
   }
 
   .start-menu__submenu {
-    max-height: 220px;
+    min-height: 0;
+    max-height: none;
   }
 
   .taskbar__item {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Make the taskbar safe-area aware so it stays fully visible on phones
- Size the desktop shell against dynamic viewport units for mobile browser chrome
- Rework the narrow start menu into a fixed, viewport-contained panel with scrollable sections/submenus
- Gate menu hover styles to fine-pointer devices to avoid sticky touch hover states

## Tests
- npm run lint
- npm run build
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-651d5ae4-2c6a-4a88-a675-03fd39296cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-651d5ae4-2c6a-4a88-a675-03fd39296cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

