### PR TITLE
Fix start menu hover flicker on long Projects list

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -499,6 +499,27 @@ a {
   }
 }
 
+@media (min-width: 761px) {
+  .start-menu[data-submenu-open="true"] {
+    grid-template-columns: minmax(0, 230px);
+  }
+
+  .start-menu[data-submenu-open="true"] .start-menu__items {
+    border-right: 0;
+  }
+
+  .start-menu__submenu {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 230px;
+    max-height: none;
+    border-left: 1px solid var(--border);
+    background: color-mix(in srgb, var(--surface) 94%, var(--surface-muted));
+  }
+}
+
 .start-menu__rail {
   display: none;
 
@@ -589,6 +610,7 @@ a {
   min-height: 0;
   max-height: inherit;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   padding: 8px;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In desktop mode, hovering the **Projects** section in the start menu caused a rapid layout shift loop. The Projects submenu has many items, so opening it increased the overall menu height. Because the menu is anchored from the bottom, section rows shifted upward under the cursor, which triggered hover on a different section, which changed the submenu height again — creating a flickering feedback loop.

## Solution

On desktop (`min-width: 761px`), the submenu is now **absolutely positioned** within the start menu panel instead of participating in the CSS grid layout. The menu height is determined only by the left column (sections list), while the submenu scrolls independently within that fixed vertical space.

Also added `scrollbar-gutter: stable` on the submenu to prevent layout shifts when the scrollbar appears.

## Testing

- `npm run build` passes
- Manual verification: open Start menu → hover Projects → move between sections and into the submenu without layout jumping
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efdc42bd-d514-4f60-b789-0924ba06430a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efdc42bd-d514-4f60-b789-0924ba06430a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

